### PR TITLE
Fixed the query structure of the tables to scan rows from snowflake DB Closes #77

### DIFF
--- a/snowflake/table_snowflake_account_grant.go
+++ b/snowflake/table_snowflake_account_grant.go
@@ -21,7 +21,7 @@ func tableSnowflakeAccountGrant(_ context.Context) *plugin.Table {
 			{Name: "name", Type: proto.ColumnType_STRING, Description: "An entity to which access can be granted. Unless allowed by a grant, access will be denied."},
 			{Name: "privilege", Type: proto.ColumnType_STRING, Description: "A defined level of access to an object."},
 			{Name: "created_on", Type: proto.ColumnType_TIMESTAMP, Description: "Date and time privilege was granted."},
-			{Name: "grant_option", Type: proto.ColumnType_BOOL, Description: "If set to TRUE, the recipient role can grant the privilege to other roles."},
+			{Name: "grant_option", Type: proto.ColumnType_STRING, Description: "If set to TRUE, the recipient role can grant the privilege to other roles."},
 			{Name: "granted_by", Type: proto.ColumnType_STRING, Description: "Name of the object that granted access on the role."},
 			{Name: "granted_on", Type: proto.ColumnType_STRING, Description: "Date and time when the access was granted."},
 			{Name: "granted_to", Type: proto.ColumnType_STRING, Description: "Type of the object."},
@@ -39,6 +39,7 @@ type AccountGrant struct {
 	GranteeName sql.NullString `json:"grantee_name"`
 	GrantOption sql.NullString `json:"grant_option"`
 	GrantedBy   sql.NullString `json:"granted_by"`
+	Role        sql.NullString `json:"role"`
 }
 
 //// LIST FUNCTION
@@ -66,14 +67,15 @@ func listSnowflakeAccountGrants(ctx context.Context, d *plugin.QueryData, _ *plu
 		var granteeName sql.NullString
 		var grantOption sql.NullString
 		var grantedBy sql.NullString
+		var role sql.NullString
 
-		err = rows.Scan(&createdOn, &privilege, &grantedOn, &name, &grantedTo, &granteeName, &grantOption, &grantedBy)
+		err = rows.Scan(&createdOn, &privilege, &grantedOn, &name, &grantedTo, &granteeName, &grantOption, &grantedBy, &role)
 		if err != nil {
 			logger.Error("snowflake_account_grant.listSnowflakeAccountGrants", "query_scan.error", err)
 			return nil, err
 		}
 
-		d.StreamListItem(ctx, AccountGrant{createdOn, privilege, grantedOn, name, grantedTo, granteeName, grantOption, grantedBy})
+		d.StreamListItem(ctx, AccountGrant{createdOn, privilege, grantedOn, name, grantedTo, granteeName, grantOption, grantedBy, role})
 	}
 
 	for rows.NextResultSet() {
@@ -85,14 +87,15 @@ func listSnowflakeAccountGrants(ctx context.Context, d *plugin.QueryData, _ *plu
 		var granteeName sql.NullString
 		var grantOption sql.NullString
 		var grantedBy sql.NullString
+		var role sql.NullString
 
-		err = rows.Scan(&createdOn, &privilege, &grantedOn, &name, &grantedTo, &granteeName, &grantOption, &grantedBy)
+		err = rows.Scan(&createdOn, &privilege, &grantedOn, &name, &grantedTo, &granteeName, &grantOption, &grantedBy, &role)
 		if err != nil {
 			logger.Error("snowflake_account_grant.listSnowflakeAccountGrants", "query_scan.error", err)
 			return nil, err
 		}
 
-		d.StreamListItem(ctx, AccountGrant{createdOn, privilege, grantedOn, name, grantedTo, granteeName, grantOption, grantedBy})
+		d.StreamListItem(ctx, AccountGrant{createdOn, privilege, grantedOn, name, grantedTo, granteeName, grantOption, grantedBy, role})
 	}
 	return nil, nil
 }

--- a/snowflake/table_snowflake_account_grant.go
+++ b/snowflake/table_snowflake_account_grant.go
@@ -21,7 +21,7 @@ func tableSnowflakeAccountGrant(_ context.Context) *plugin.Table {
 			{Name: "name", Type: proto.ColumnType_STRING, Description: "An entity to which access can be granted. Unless allowed by a grant, access will be denied."},
 			{Name: "privilege", Type: proto.ColumnType_STRING, Description: "A defined level of access to an object."},
 			{Name: "created_on", Type: proto.ColumnType_TIMESTAMP, Description: "Date and time privilege was granted."},
-			{Name: "grant_option", Type: proto.ColumnType_STRING, Description: "If set to TRUE, the recipient role can grant the privilege to other roles."},
+			{Name: "grant_option", Type: proto.ColumnType_BOOL, Description: "If set to TRUE, the recipient role can grant the privilege to other roles."},
 			{Name: "granted_by", Type: proto.ColumnType_STRING, Description: "Name of the object that granted access on the role."},
 			{Name: "granted_on", Type: proto.ColumnType_STRING, Description: "Date and time when the access was granted."},
 			{Name: "granted_to", Type: proto.ColumnType_STRING, Description: "Type of the object."},
@@ -37,7 +37,7 @@ type AccountGrant struct {
 	Name        sql.NullString `json:"name"`
 	GrantedTo   sql.NullString `json:"granted_to"`
 	GranteeName sql.NullString `json:"grantee_name"`
-	GrantOption sql.NullString `json:"grant_option"`
+	GrantOption sql.NullBool `json:"grant_option"`
 	GrantedBy   sql.NullString `json:"granted_by"`
 	Role        sql.NullString `json:"role"`
 }
@@ -65,7 +65,7 @@ func listSnowflakeAccountGrants(ctx context.Context, d *plugin.QueryData, _ *plu
 		var name sql.NullString
 		var grantedTo sql.NullString
 		var granteeName sql.NullString
-		var grantOption sql.NullString
+		var grantOption sql.NullBool
 		var grantedBy sql.NullString
 		var role sql.NullString
 
@@ -85,7 +85,7 @@ func listSnowflakeAccountGrants(ctx context.Context, d *plugin.QueryData, _ *plu
 		var name sql.NullString
 		var grantedTo sql.NullString
 		var granteeName sql.NullString
-		var grantOption sql.NullString
+		var grantOption sql.NullBool
 		var grantedBy sql.NullString
 		var role sql.NullString
 

--- a/snowflake/table_snowflake_database.go
+++ b/snowflake/table_snowflake_database.go
@@ -42,6 +42,9 @@ type Database struct {
 	Comment       sql.NullString `json:"comment"`
 	Options       sql.NullString `json:"options"`
 	RetentionTime sql.NullString `json:"retention_time"`
+	Kind          sql.NullString `json:"kind"`
+	Budget        sql.NullString `json:"budget"`
+	OwnerRoleType sql.NullString `json:"owner_role_type"`
 }
 
 //// LIST FUNCTION
@@ -70,14 +73,17 @@ func listSnowflakeDatabases(ctx context.Context, d *plugin.QueryData, _ *plugin.
 		var Comment sql.NullString
 		var Options sql.NullString
 		var RetentionTime sql.NullString
+		var Kind sql.NullString
+		var Budget sql.NullString
+		var OwnerRoleType sql.NullString
 
-		err = rows.Scan(&CreatedOn, &Name, &IsDefault, &IsCurrent, &Origin, &Owner, &Comment, &Options, &RetentionTime)
+		err = rows.Scan(&CreatedOn, &Name, &IsDefault, &IsCurrent, &Origin, &Owner, &Comment, &Options, &RetentionTime, &Kind, &Budget, &OwnerRoleType)
 		if err != nil {
 			logger.Error("snowflake_database.listSnowflakeDatabases", "query.error", err)
 			return nil, err
 		}
 
-		d.StreamListItem(ctx, Database{CreatedOn, Name, IsDefault, IsCurrent, Origin, Owner, Comment, Options, RetentionTime})
+		d.StreamListItem(ctx, Database{CreatedOn, Name, IsDefault, IsCurrent, Origin, Owner, Comment, Options, RetentionTime, Kind, Budget, Owner})
 	}
 
 	for rows.NextResultSet() {
@@ -91,14 +97,17 @@ func listSnowflakeDatabases(ctx context.Context, d *plugin.QueryData, _ *plugin.
 			var Comment sql.NullString
 			var Options sql.NullString
 			var RetentionTime sql.NullString
+			var Kind sql.NullString
+			var Budget sql.NullString
+			var OwnerRoleType sql.NullString
 
-			err = rows.Scan(&CreatedOn, &Name, &IsDefault, &IsCurrent, &Origin, &Owner, &Comment, &Options, &RetentionTime)
+			err = rows.Scan(&CreatedOn, &Name, &IsDefault, &IsCurrent, &Origin, &Owner, &Comment, &Options, &RetentionTime, &Kind, &Budget, &OwnerRoleType)
 			if err != nil {
 				logger.Error("snowflake_database.listSnowflakeDatabases", "query.error", err)
 				return nil, err
 			}
 
-			d.StreamListItem(ctx, Database{CreatedOn, Name, IsDefault, IsCurrent, Origin, Owner, Comment, Options, RetentionTime})
+			d.StreamListItem(ctx, Database{CreatedOn, Name, IsDefault, IsCurrent, Origin, Owner, Comment, Options, RetentionTime, Kind, Budget, Owner})
 		}
 	}
 	return nil, nil

--- a/snowflake/table_snowflake_database_grant.go
+++ b/snowflake/table_snowflake_database_grant.go
@@ -27,7 +27,7 @@ func tableSnowflakeDatabaseGrant(_ context.Context) *plugin.Table {
 			{Name: "database", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name").Transform(valueFromNullable), Description: "Name of the database."},
 			{Name: "privilege", Type: proto.ColumnType_STRING, Description: "A defined level of access to an database."},
 			{Name: "created_on", Type: proto.ColumnType_TIMESTAMP, Description: "Date and time when the access was granted."},
-			{Name: "grant_option", Type: proto.ColumnType_STRING, Description: "If set to TRUE, the recipient role can grant the privilege to other roles."},
+			{Name: "grant_option", Type: proto.ColumnType_BOOL, Description: "If set to TRUE, the recipient role can grant the privilege to other roles."},
 			{Name: "granted_by", Type: proto.ColumnType_STRING, Description: "Identifier for the object that granted the privilege."},
 			{Name: "granted_on", Type: proto.ColumnType_STRING, Description: "Type of the object."},
 			{Name: "granted_to", Type: proto.ColumnType_STRING, Description: "Type of the object role has been granted."},
@@ -66,7 +66,7 @@ func listSnowflakeDatabaseGrants(ctx context.Context, d *plugin.QueryData, _ *pl
 		var name sql.NullString
 		var grantedTo sql.NullString
 		var granteeName sql.NullString
-		var grantOption sql.NullString
+		var grantOption sql.NullBool
 		var grantedBy sql.NullString
 		var role sql.NullString
 
@@ -87,7 +87,7 @@ func listSnowflakeDatabaseGrants(ctx context.Context, d *plugin.QueryData, _ *pl
 			var name sql.NullString
 			var grantedTo sql.NullString
 			var granteeName sql.NullString
-			var grantOption sql.NullString
+			var grantOption sql.NullBool
 			var grantedBy sql.NullString
 			var role sql.NullString
 

--- a/snowflake/table_snowflake_database_grant.go
+++ b/snowflake/table_snowflake_database_grant.go
@@ -27,7 +27,7 @@ func tableSnowflakeDatabaseGrant(_ context.Context) *plugin.Table {
 			{Name: "database", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name").Transform(valueFromNullable), Description: "Name of the database."},
 			{Name: "privilege", Type: proto.ColumnType_STRING, Description: "A defined level of access to an database."},
 			{Name: "created_on", Type: proto.ColumnType_TIMESTAMP, Description: "Date and time when the access was granted."},
-			{Name: "grant_option", Type: proto.ColumnType_BOOL, Description: "If set to TRUE, the recipient role can grant the privilege to other roles."},
+			{Name: "grant_option", Type: proto.ColumnType_STRING, Description: "If set to TRUE, the recipient role can grant the privilege to other roles."},
 			{Name: "granted_by", Type: proto.ColumnType_STRING, Description: "Identifier for the object that granted the privilege."},
 			{Name: "granted_on", Type: proto.ColumnType_STRING, Description: "Type of the object."},
 			{Name: "granted_to", Type: proto.ColumnType_STRING, Description: "Type of the object role has been granted."},
@@ -68,14 +68,15 @@ func listSnowflakeDatabaseGrants(ctx context.Context, d *plugin.QueryData, _ *pl
 		var granteeName sql.NullString
 		var grantOption sql.NullString
 		var grantedBy sql.NullString
+		var role sql.NullString
 
-		err = rows.Scan(&createdOn, &privilege, &grantedOn, &name, &grantedTo, &granteeName, &grantOption, &grantedBy)
+		err = rows.Scan(&createdOn, &privilege, &grantedOn, &name, &grantedTo, &granteeName, &grantOption, &grantedBy, &role)
 		if err != nil {
 			logger.Error("snowflake_database_grant.listSnowflakeDatabaseGrants", "query_scan.error", err)
 			return nil, err
 		}
 
-		d.StreamListItem(ctx, DatabaseGrant{createdOn, privilege, grantedOn, name, grantedTo, granteeName, grantOption, grantedBy})
+		d.StreamListItem(ctx, DatabaseGrant{createdOn, privilege, grantedOn, name, grantedTo, granteeName, grantOption, grantedBy, role})
 	}
 
 	for rows.NextResultSet() {
@@ -88,14 +89,15 @@ func listSnowflakeDatabaseGrants(ctx context.Context, d *plugin.QueryData, _ *pl
 			var granteeName sql.NullString
 			var grantOption sql.NullString
 			var grantedBy sql.NullString
+			var role sql.NullString
 
-			err = rows.Scan(&createdOn, &privilege, &grantedOn, &name, &grantedTo, &granteeName, &grantOption, &grantedBy)
+			err = rows.Scan(&createdOn, &privilege, &grantedOn, &name, &grantedTo, &granteeName, &grantOption, &grantedBy, &role)
 			if err != nil {
 				logger.Error("snowflake_database_grant.listSnowflakeDatabaseGrants", "query_scan.error", err)
 				return nil, err
 			}
 
-			d.StreamListItem(ctx, DatabaseGrant{createdOn, privilege, grantedOn, name, grantedTo, granteeName, grantOption, grantedBy})
+			d.StreamListItem(ctx, DatabaseGrant{createdOn, privilege, grantedOn, name, grantedTo, granteeName, grantOption, grantedBy, role})
 		}
 	}
 	return nil, nil

--- a/snowflake/table_snowflake_login_history.go
+++ b/snowflake/table_snowflake_login_history.go
@@ -58,6 +58,7 @@ type LoginHistory struct {
 	ErrorCode                  sql.NullInt64  `json:"ERROR_CODE"`
 	ErrorMessage               sql.NullString `json:"ERROR_MESSAGE"`
 	RelatedEventId             sql.NullInt64  `json:"RELATED_EVENT_ID"`
+	Connection                 sql.NullString `json:"CONNECTION"`
 }
 
 // LoginHistoryCol returns a reference for a column of a LoginHistory
@@ -89,6 +90,8 @@ func LoginHistoryCol(colname string, item *LoginHistory) interface{} {
 		return &item.ErrorMessage
 	case "RELATED_EVENT_ID":
 		return &item.RelatedEventId
+	case "CONNECTION":
+		return &item.Connection
 	default:
 		panic("unknown column " + colname)
 	}

--- a/snowflake/table_snowflake_network_policy.go
+++ b/snowflake/table_snowflake_network_policy.go
@@ -5,9 +5,9 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
 )
 
 //// TABLE DEFINITION
@@ -34,11 +34,13 @@ func tableSnowflakeNetworkPolicy(_ context.Context) *plugin.Table {
 }
 
 type NetworkPolicy struct {
-	Name                   sql.NullString `json:"name"`
-	CreatedOn              sql.NullTime   `json:"created_on"`
-	Comment                sql.NullString `json:"comment"`
-	EntriesInAllowedIPList sql.NullInt64  `json:"entries_in_allowed_ip_list"`
-	EntriesInBlockedIPList sql.NullInt64  `json:"entries_in_blocked_ip_list"`
+	Name                         sql.NullString `json:"name"`
+	CreatedOn                    sql.NullTime   `json:"created_on"`
+	Comment                      sql.NullString `json:"comment"`
+	EntriesInAllowedIPList       sql.NullInt64  `json:"entries_in_allowed_ip_list"`
+	EntriesInBlockedIPList       sql.NullInt64  `json:"entries_in_blocked_ip_list"`
+	EntriesInAllowedNetworkRules sql.NullString `json:"entries_in_allowed_network_rules"`
+	EntriesInBlockedNetworkRules sql.NullString `json:"entries_in_blocked_network_rules"`
 }
 
 //// LIST FUNCTION
@@ -63,14 +65,16 @@ func listSnowflakeNetworkPolicies(ctx context.Context, d *plugin.QueryData, _ *p
 		var Comment sql.NullString
 		var EntriesInAllowedIPList sql.NullInt64
 		var EntriesInBlockedIPList sql.NullInt64
+		var EntriesInAllowedNetworkRules sql.NullString
+		var EntriesInBlockedNetworkRules sql.NullString
 
-		err = rows.Scan(&CreatedOn, &Name, &Comment, &EntriesInAllowedIPList, &EntriesInBlockedIPList)
+		err = rows.Scan(&CreatedOn, &Name, &Comment, &EntriesInAllowedIPList, &EntriesInBlockedIPList, &EntriesInAllowedNetworkRules, &EntriesInBlockedNetworkRules)
 		if err != nil {
 			logger.Error("snowflake_network_policy.listSnowflakeNetworkPolicies", "query.error", err)
 			return nil, err
 		}
 
-		d.StreamListItem(ctx, NetworkPolicy{Name, CreatedOn, Comment, EntriesInAllowedIPList, EntriesInBlockedIPList})
+		d.StreamListItem(ctx, NetworkPolicy{Name, CreatedOn, Comment, EntriesInAllowedIPList, EntriesInBlockedIPList, EntriesInAllowedNetworkRules, EntriesInBlockedNetworkRules})
 	}
 
 	for rows.NextResultSet() {
@@ -80,14 +84,16 @@ func listSnowflakeNetworkPolicies(ctx context.Context, d *plugin.QueryData, _ *p
 			var Comment sql.NullString
 			var EntriesInAllowedIPList sql.NullInt64
 			var EntriesInBlockedIPList sql.NullInt64
+			var EntriesInAllowedNetworkRules sql.NullString
+			var EntriesInBlockedNetworkRules sql.NullString
 
-			err = rows.Scan(&CreatedOn, &Name, &Comment, &EntriesInAllowedIPList, &EntriesInBlockedIPList)
+			err = rows.Scan(&CreatedOn, &Name, &Comment, &EntriesInAllowedIPList, &EntriesInBlockedIPList, &EntriesInAllowedNetworkRules, &EntriesInBlockedNetworkRules)
 			if err != nil {
 				logger.Error("snowflake_network_policy.listSnowflakeNetworkPolicies", "query.error", err)
 				return nil, err
 			}
 
-			d.StreamListItem(ctx, NetworkPolicy{Name, CreatedOn, Comment, EntriesInAllowedIPList, EntriesInBlockedIPList})
+			d.StreamListItem(ctx, NetworkPolicy{Name, CreatedOn, Comment, EntriesInAllowedIPList, EntriesInBlockedIPList, EntriesInAllowedNetworkRules, EntriesInBlockedNetworkRules})
 		}
 	}
 

--- a/snowflake/table_snowflake_schemata.go
+++ b/snowflake/table_snowflake_schemata.go
@@ -52,6 +52,10 @@ type Schemata struct {
 	Created                    sql.NullTime   `json:"CREATED"`
 	LastAltered                sql.NullTime   `json:"LAST_ALTERED"`
 	Deleted                    sql.NullTime   `json:"DELETED"`
+	OwnerRoleType              sql.NullString `json:"OWNER_ROLE_TYPE"`
+	SchemaType                 sql.NullString `json:"SCHEMA_TYPE"`
+	VersionName                sql.NullString `json:"VERSION_NAME"`
+	VersionedSchemaId          sql.NullString `json:"VERSIONED_SCHEMA_ID"`
 }
 
 // SchemataCol returns a reference for a column of a Schemata
@@ -89,6 +93,14 @@ func SchemataCol(colname string, item *Schemata) interface{} {
 		return &item.LastAltered
 	case "DELETED":
 		return &item.Deleted
+	case "OWNER_ROLE_TYPE":
+		return &item.OwnerRoleType
+	case "SCHEMA_TYPE":
+		return &item.SchemaType
+	case "VERSION_NAME":
+		return &item.VersionName
+	case "VERSIONED_SCHEMA_ID":
+		return &item.VersionedSchemaId
 	default:
 		panic("unknown column " + colname)
 	}

--- a/snowflake/table_snowflake_session.go
+++ b/snowflake/table_snowflake_session.go
@@ -55,6 +55,7 @@ type Session struct {
 	ClientEnvironment        sql.NullString `json:"CLIENT_ENVIRONMENT"`
 	ClientBuildId            sql.NullString `json:"CLIENT_BUILD_ID"`
 	ClientVersion            sql.NullString `json:"CLIENT_VERSION"`
+	ClosedReason             sql.NullString `json:"CLOSED_REASON"`
 }
 
 // SessionCol returns a reference for a column of a Session
@@ -80,6 +81,8 @@ func SessionCol(colname string, item *Session) interface{} {
 		return &item.ClientBuildId
 	case "CLIENT_VERSION":
 		return &item.ClientVersion
+	case "CLOSED_REASON":
+		return &item.ClosedReason
 	default:
 		panic("unknown column " + colname)
 	}

--- a/snowflake/table_snowflake_user.go
+++ b/snowflake/table_snowflake_user.go
@@ -88,6 +88,8 @@ type User struct {
 	LockedUntilTime       sql.NullTime   `json:"locked_until_time"`
 	HasPassword           sql.NullString `json:"has_password"`
 	HasRsaPublicKey       sql.NullString `json:"has_rsa_public_key"`
+	Type                  sql.NullString `json:"type"`
+	HasMFA                sql.NullBool  `json:"has_mfa"`
 }
 
 //// LIST FUNCTION
@@ -133,14 +135,16 @@ func listSnowflakeUsers(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 		var LockedUntilTime sql.NullTime
 		var HasPassword sql.NullString
 		var HasRSAPublicKey sql.NullString
+		var Type sql.NullString
+		var HasMFA                sql.NullBool
 
-		err = rows.Scan(&Name, &CreatedOn, &LoginName, &DisplayName, &FirstName, &LastName, &Email, &MinsToUnlock, &DaysToExpiry, &Comment, &Disabled, &MustChangePassword, &SnowflakeLock, &DefaultWarehouse, &DefaultNamespace, &DefaultRole, &DefaultSecondaryRoles, &ExtAuthnDuo, &ExtAuthnUid, &MinsToBypassMFA, &Owner, &LastSuccessLogin, &ExpiresAtTime, &LockedUntilTime, &HasPassword, &HasRSAPublicKey)
+		err = rows.Scan(&Name, &CreatedOn, &LoginName, &DisplayName, &FirstName, &LastName, &Email, &MinsToUnlock, &DaysToExpiry, &Comment, &Disabled, &MustChangePassword, &SnowflakeLock, &DefaultWarehouse, &DefaultNamespace, &DefaultRole, &DefaultSecondaryRoles, &ExtAuthnDuo, &ExtAuthnUid, &MinsToBypassMFA, &Owner, &LastSuccessLogin, &ExpiresAtTime, &LockedUntilTime, &HasPassword, &HasRSAPublicKey, &Type, &HasMFA)
 		if err != nil {
 			logger.Error("snowflake_user.listSnowflakeUsers", "query_scan.error", err)
 			return nil, err
 		}
 
-		d.StreamListItem(ctx, User{Name, CreatedOn, LoginName, DisplayName, FirstName, LastName, Email, MinsToUnlock, DaysToExpiry, Comment, Disabled, MustChangePassword, SnowflakeLock, DefaultWarehouse, DefaultNamespace, DefaultRole, DefaultSecondaryRoles, ExtAuthnDuo, ExtAuthnUid, MinsToBypassMFA, Owner, LastSuccessLogin, ExpiresAtTime, LockedUntilTime, HasPassword, HasRSAPublicKey})
+		d.StreamListItem(ctx, User{Name, CreatedOn, LoginName, DisplayName, FirstName, LastName, Email, MinsToUnlock, DaysToExpiry, Comment, Disabled, MustChangePassword, SnowflakeLock, DefaultWarehouse, DefaultNamespace, DefaultRole, DefaultSecondaryRoles, ExtAuthnDuo, ExtAuthnUid, MinsToBypassMFA, Owner, LastSuccessLogin, ExpiresAtTime, LockedUntilTime, HasPassword, HasRSAPublicKey, Type, HasMFA})
 	}
 
 	for rows.NextResultSet() {
@@ -171,14 +175,16 @@ func listSnowflakeUsers(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 			var LockedUntilTime sql.NullTime
 			var HasPassword sql.NullString
 			var HasRSAPublicKey sql.NullString
+			var Type sql.NullString
+			var HasMFA sql.NullBool
 
-			err = rows.Scan(&Name, &CreatedOn, &LoginName, &DisplayName, &FirstName, &LastName, &Email, &MinsToUnlock, &DaysToExpiry, &Comment, &Disabled, &MustChangePassword, &SnowflakeLock, &DefaultWarehouse, &DefaultNamespace, &DefaultRole, &DefaultSecondaryRoles, &ExtAuthnDuo, &ExtAuthnUid, &MinsToBypassMFA, &Owner, &LastSuccessLogin, &ExpiresAtTime, &LockedUntilTime, &HasPassword, &HasRSAPublicKey)
+			err = rows.Scan(&Name, &CreatedOn, &LoginName, &DisplayName, &FirstName, &LastName, &Email, &MinsToUnlock, &DaysToExpiry, &Comment, &Disabled, &MustChangePassword, &SnowflakeLock, &DefaultWarehouse, &DefaultNamespace, &DefaultRole, &DefaultSecondaryRoles, &ExtAuthnDuo, &ExtAuthnUid, &MinsToBypassMFA, &Owner, &LastSuccessLogin, &ExpiresAtTime, &LockedUntilTime, &HasPassword, &HasRSAPublicKey, &Type, &HasMFA)
 			if err != nil {
 				logger.Error("snowflake_user.listSnowflakeUsers", "query_scan.error", err)
 				return nil, err
 			}
 
-			d.StreamListItem(ctx, User{Name, CreatedOn, LoginName, DisplayName, FirstName, LastName, Email, MinsToUnlock, DaysToExpiry, Comment, Disabled, MustChangePassword, SnowflakeLock, DefaultWarehouse, DefaultNamespace, DefaultRole, DefaultSecondaryRoles, ExtAuthnDuo, ExtAuthnUid, MinsToBypassMFA, Owner, LastSuccessLogin, ExpiresAtTime, LockedUntilTime, HasPassword, HasRSAPublicKey})
+			d.StreamListItem(ctx, User{Name, CreatedOn, LoginName, DisplayName, FirstName, LastName, Email, MinsToUnlock, DaysToExpiry, Comment, Disabled, MustChangePassword, SnowflakeLock, DefaultWarehouse, DefaultNamespace, DefaultRole, DefaultSecondaryRoles, ExtAuthnDuo, ExtAuthnUid, MinsToBypassMFA, Owner, LastSuccessLogin, ExpiresAtTime, LockedUntilTime, HasPassword, HasRSAPublicKey, Type, HasMFA})
 		}
 	}
 	return nil, nil

--- a/snowflake/table_snowflake_user.go
+++ b/snowflake/table_snowflake_user.go
@@ -89,7 +89,7 @@ type User struct {
 	HasPassword           sql.NullString `json:"has_password"`
 	HasRsaPublicKey       sql.NullString `json:"has_rsa_public_key"`
 	Type                  sql.NullString `json:"type"`
-	HasMFA                sql.NullBool  `json:"has_mfa"`
+	HasMFA                sql.NullBool   `json:"has_mfa"`
 }
 
 //// LIST FUNCTION
@@ -136,7 +136,7 @@ func listSnowflakeUsers(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 		var HasPassword sql.NullString
 		var HasRSAPublicKey sql.NullString
 		var Type sql.NullString
-		var HasMFA                sql.NullBool
+		var HasMFA sql.NullBool
 
 		err = rows.Scan(&Name, &CreatedOn, &LoginName, &DisplayName, &FirstName, &LastName, &Email, &MinsToUnlock, &DaysToExpiry, &Comment, &Disabled, &MustChangePassword, &SnowflakeLock, &DefaultWarehouse, &DefaultNamespace, &DefaultRole, &DefaultSecondaryRoles, &ExtAuthnDuo, &ExtAuthnUid, &MinsToBypassMFA, &Owner, &LastSuccessLogin, &ExpiresAtTime, &LockedUntilTime, &HasPassword, &HasRSAPublicKey, &Type, &HasMFA)
 		if err != nil {

--- a/snowflake/table_snowflake_view.go
+++ b/snowflake/table_snowflake_view.go
@@ -43,6 +43,8 @@ type View struct {
 	Text           sql.NullString `json:"text"`
 	IsSecure       sql.NullString `json:"is_secure"`
 	IsMaterialized sql.NullString `json:"is_materialized"`
+	TableName      sql.NullString `json:"table_name"`
+	TableCatalog   sql.NullString `json:"table_catalog"`
 }
 
 //// LIST FUNCTION
@@ -72,14 +74,16 @@ func listSnowflakeViews(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 		var text sql.NullString
 		var isSecure sql.NullString
 		var isMaterialized sql.NullString
+		var tableName sql.NullString
+		var tableCatalog sql.NullString
 
-		err = rows.Scan(&createdOn, &name, &reserved, &databaseName, &schemaName, &owner, &comment, &text, &isSecure, &isMaterialized)
+		err = rows.Scan(&createdOn, &name, &reserved, &databaseName, &schemaName, &owner, &comment, &text, &isSecure, &isMaterialized, &tableName, &tableCatalog)
 		if err != nil {
 			logger.Error("snowflake_view.listSnowflakeViews", "query_scan.error", err)
 			return nil, err
 		}
 
-		d.StreamListItem(ctx, View{createdOn, name, reserved, databaseName, schemaName, owner, comment, text, isSecure, isMaterialized})
+		d.StreamListItem(ctx, View{createdOn, name, reserved, databaseName, schemaName, owner, comment, text, isSecure, isMaterialized, tableName, tableCatalog})
 	}
 
 	for rows.NextResultSet() {
@@ -94,12 +98,16 @@ func listSnowflakeViews(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 			var text sql.NullString
 			var isSecure sql.NullString
 			var isMaterialized sql.NullString
-			err = rows.Scan(&createdOn, &name, &reserved, &databaseName, &schemaName, &owner, &comment, &text, &isSecure, &isMaterialized)
+			var tableName sql.NullString
+			var tableCatalog sql.NullString
+
+			err = rows.Scan(&createdOn, &name, &reserved, &databaseName, &schemaName, &owner, &comment, &text, &isSecure, &isMaterialized, &tableName, &tableCatalog)
 			if err != nil {
 				logger.Error("snowflake_view.listSnowflakeViews", "query_scan.error", err)
 				return nil, err
 			}
-			d.StreamListItem(ctx, View{createdOn, name, reserved, databaseName, schemaName, owner, comment, text, isSecure, isMaterialized})
+
+			d.StreamListItem(ctx, View{createdOn, name, reserved, databaseName, schemaName, owner, comment, text, isSecure, isMaterialized, tableName, tableCatalog})
 		}
 	}
 	return nil, nil

--- a/snowflake/table_snowflake_view_grant.go
+++ b/snowflake/table_snowflake_view_grant.go
@@ -31,7 +31,7 @@ func tableSnowflakeViewGrant(_ context.Context) *plugin.Table {
 			{Name: "schema_name", Type: proto.ColumnType_STRING, Transform: transform.FromQual("schema_name"), Description: "The name of the schema in which the view exists."},
 			{Name: "privilege", Type: proto.ColumnType_STRING, Description: "A defined level of access to an object."},
 			{Name: "created_on", Type: proto.ColumnType_TIMESTAMP, Description: "Date and time privilege was granted."},
-			{Name: "grant_option", Type: proto.ColumnType_STRING, Description: "If set to TRUE, the recipient role can grant the privilege to other roles."},
+			{Name: "grant_option", Type: proto.ColumnType_BOOL, Description: "If set to TRUE, the recipient role can grant the privilege to other roles."},
 			{Name: "granted_by", Type: proto.ColumnType_STRING, Description: "Name of the object that granted access on the role."},
 			{Name: "granted_on", Type: proto.ColumnType_STRING, Description: "Date and time when the access was granted."},
 			{Name: "granted_to", Type: proto.ColumnType_STRING, Description: "Type of the object."},
@@ -77,7 +77,7 @@ func listSnowflakeViewGrants(ctx context.Context, d *plugin.QueryData, _ *plugin
 		var name sql.NullString
 		var grantedTo sql.NullString
 		var granteeName sql.NullString
-		var grantOption sql.NullString
+		var grantOption sql.NullBool
 		var grantedBy sql.NullString
 		var role sql.NullString
 
@@ -98,7 +98,7 @@ func listSnowflakeViewGrants(ctx context.Context, d *plugin.QueryData, _ *plugin
 			var name sql.NullString
 			var grantedTo sql.NullString
 			var granteeName sql.NullString
-			var grantOption sql.NullString
+			var grantOption sql.NullBool
 			var grantedBy sql.NullString
 			var role sql.NullString
 

--- a/snowflake/table_snowflake_view_grant.go
+++ b/snowflake/table_snowflake_view_grant.go
@@ -31,7 +31,7 @@ func tableSnowflakeViewGrant(_ context.Context) *plugin.Table {
 			{Name: "schema_name", Type: proto.ColumnType_STRING, Transform: transform.FromQual("schema_name"), Description: "The name of the schema in which the view exists."},
 			{Name: "privilege", Type: proto.ColumnType_STRING, Description: "A defined level of access to an object."},
 			{Name: "created_on", Type: proto.ColumnType_TIMESTAMP, Description: "Date and time privilege was granted."},
-			{Name: "grant_option", Type: proto.ColumnType_BOOL, Description: "If set to TRUE, the recipient role can grant the privilege to other roles."},
+			{Name: "grant_option", Type: proto.ColumnType_STRING, Description: "If set to TRUE, the recipient role can grant the privilege to other roles."},
 			{Name: "granted_by", Type: proto.ColumnType_STRING, Description: "Name of the object that granted access on the role."},
 			{Name: "granted_on", Type: proto.ColumnType_STRING, Description: "Date and time when the access was granted."},
 			{Name: "granted_to", Type: proto.ColumnType_STRING, Description: "Type of the object."},
@@ -79,14 +79,15 @@ func listSnowflakeViewGrants(ctx context.Context, d *plugin.QueryData, _ *plugin
 		var granteeName sql.NullString
 		var grantOption sql.NullString
 		var grantedBy sql.NullString
+		var role sql.NullString
 
-		err = rows.Scan(&createdOn, &privilege, &grantedOn, &name, &grantedTo, &granteeName, &grantOption, &grantedBy)
+		err = rows.Scan(&createdOn, &privilege, &grantedOn, &name, &grantedTo, &granteeName, &grantOption, &grantedBy, &role)
 		if err != nil {
 			logger.Error("snowflake_view_grant.listSnowflakeViewGrants", "query_scan.error", err)
 			return nil, err
 		}
 
-		d.StreamListItem(ctx, ViewGrant{createdOn, privilege, grantedOn, name, grantedTo, granteeName, grantOption, grantedBy})
+		d.StreamListItem(ctx, ViewGrant{createdOn, privilege, grantedOn, name, grantedTo, granteeName, grantOption, grantedBy, role})
 	}
 
 	for rows.NextResultSet() {
@@ -99,14 +100,15 @@ func listSnowflakeViewGrants(ctx context.Context, d *plugin.QueryData, _ *plugin
 			var granteeName sql.NullString
 			var grantOption sql.NullString
 			var grantedBy sql.NullString
+			var role sql.NullString
 
-			err = rows.Scan(&createdOn, &privilege, &grantedOn, &name, &grantedTo, &granteeName, &grantOption, &grantedBy)
+			err = rows.Scan(&createdOn, &privilege, &grantedOn, &name, &grantedTo, &granteeName, &grantOption, &grantedBy, &role)
 			if err != nil {
 				logger.Error("snowflake_view_grant.listSnowflakeViewGrants", "query_scan.error", err)
 				return nil, err
 			}
 
-			d.StreamListItem(ctx, ViewGrant{createdOn, privilege, grantedOn, name, grantedTo, granteeName, grantOption, grantedBy})
+			d.StreamListItem(ctx, ViewGrant{createdOn, privilege, grantedOn, name, grantedTo, granteeName, grantOption, grantedBy, role})
 		}
 	}
 	return nil, nil

--- a/snowflake/table_snowflake_warehouse.go
+++ b/snowflake/table_snowflake_warehouse.go
@@ -77,6 +77,8 @@ type Warehouse struct {
 	Suspended       sql.NullInt64  `json:"suspended" db:"suspended"`
 	UUID            sql.NullString `json:"uuid" db:"uuid"`
 	ScalingPolicy   sql.NullString `json:"scaling_policy" db:"scaling_policy"`
+	Budget          sql.NullString `json:"budget" db:"budget"`
+	OwnerRoleType          sql.NullString `json:"owner_role_type" db:"owner_role_type"`
 }
 
 //// LIST FUNCTION

--- a/snowflake/table_snowflake_warehouse.go
+++ b/snowflake/table_snowflake_warehouse.go
@@ -78,7 +78,7 @@ type Warehouse struct {
 	UUID            sql.NullString `json:"uuid" db:"uuid"`
 	ScalingPolicy   sql.NullString `json:"scaling_policy" db:"scaling_policy"`
 	Budget          sql.NullString `json:"budget" db:"budget"`
-	OwnerRoleType          sql.NullString `json:"owner_role_type" db:"owner_role_type"`
+	OwnerRoleType   sql.NullString `json:"owner_role_type" db:"owner_role_type"`
 }
 
 //// LIST FUNCTION


### PR DESCRIPTION
# Example query results

<details>
  <summary>Results</summary>

```
> select * from snowflake_user_grant where username = 'PARTHA'
+----------+--------------+---------------------------+------------+------------+----------------+---------+--------------------+----------------------------------------------------------------------+----------------------------------------------------------------------+
| username | role         | created_on                | granted_to | granted_by | region         | account | sp_connection_name | sp_ctx                                                               | _ctx                                                                 |
+----------+--------------+---------------------------+------------+------------+----------------+---------+--------------------+----------------------------------------------------------------------+----------------------------------------------------------------------+
| PARTHA   | ACCOUNTADMIN | 2024-09-04T20:12:21+05:30 | USER       |            | ap-southeast-1 | en54885 | snowflake          | {"connection_name":"snowflake","steampipe":{"sdk_version":"5.10.1"}} | {"connection_name":"snowflake","steampipe":{"sdk_version":"5.10.1"}} |
| PARTHA   | ORGADMIN     | 2024-09-04T20:12:26+05:30 | USER       |            | ap-southeast-1 | en54885 | snowflake          | {"connection_name":"snowflake","steampipe":{"sdk_version":"5.10.1"}} | {"connection_name":"snowflake","steampipe":{"sdk_version":"5.10.1"}} |
+----------+--------------+---------------------------+------------+------------+----------------+---------+--------------------+----------------------------------------------------------------------+----------------------------------------------------------------------+

> select * from snowflake_session
+-------------+-----------+---------------------------+-----------------------+-----------------------+----------------------------+-----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| session_id  | user_name | created_on                | authentication_method | client_application_id | client_application_version | client_build_id | client_environment                                                                                                                                                 >
+-------------+-----------+---------------------------+-----------------------+-----------------------+----------------------------+-----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| 43424309273 | PARTHA    | 2024-09-05T10:07:18+05:30 | Password              | Go 1.10.1             | 1.10.1                     |                 | {"APPLICATION":"Go","GO_VERSION":"go1.21.4","OCSP_MODE":"FAIL_OPEN","OS":"darwin","OS_VERSION":"gc-arm64"}                                                         >
| 43424296889 | PARTHA    | 2024-09-05T09:50:06+05:30 | OAuth                 | Go 1.1.5              | 1.1.5                      |                 | {"APPLICATION":"Snowflake Web App"}                                                                                                                                >
| 43424302809 | PARTHA    | 2024-09-05T09:50:05+05:30 | OAuth                 | Go 1.1.5              | 1.1.5                      |                 | {"APPLICATION":"Snowflake Web App"}                                                                                                                                >
| 43424306325 | PARTHA    | 2024-09-05T09:36:36+05:30 | Password              | Go 1.10.1             | 1.10.1                     |                 | {"APPLICATION":"Go","GO_VERSION":"go1.21.4","OCSP_MODE":"FAIL_OPEN","OS":"darwin","OS_VERSION":"gc-arm64"}                                                         >
| 43424306329 | PARTHA    | 2024-09-05T09:50:06+05:30 | OAuth                 | Go 1.1.5              | 1.1.5                      |                 | {"APPLICATION":"Snowflake Web App"}                                                                                                                                >
| 43424302845 | PARTHA    | 2024-09-05T10:34:11+05:30 | Password              | Go 1.10.1             | 1.10.1                     |                 | {"APPLICATION":"Go","GO_VERSION":"go1.21.4","OCSP_MODE":"FAIL_OPEN","OS":"darwin","OS_VERSION":"gc-arm64"}                                                         >
| 43424297145 | PARTHA    | 2024-09-04T20:59:57+05:30 | OAuth                 | Snowflake UI 1.1.5    | 1.1.5                      | 0               | {"APPLICATION":"Snowflake Web App (Search)"}                                                                                                                       >

> select * from snowflake_schemata
+-----------+--------------------------+------------+--------------+--------------+----------------+--------------+-------------------+---------+---------------------------+---------------------------+---------------------------+----------------+---------+--------------------+------------------------------------->
| schema_id | schema_name              | catalog_id | catalog_name | schema_owner | retention_time | is_transient | is_managed_access | comment | created                   | last_altered              | deleted                   | region         | account | sp_connection_name | sp_ctx                              >
+-----------+--------------------------+------------+--------------+--------------+----------------+--------------+-------------------+---------+---------------------------+---------------------------+---------------------------+----------------+---------+--------------------+------------------------------------->
| 4         | ORGANIZATION_USAGE_LOCAL | 1          | SNOWFLAKE    | SNOWFLAKE    | 1              | NO           | NO                | <null>  | 2024-09-04T20:41:19+05:30 | 2024-09-04T20:42:26+05:30 | 2024-09-04T20:42:26+05:30 | ap-southeast-1 | en54885 | snowflake          | {"connection_name":"snowflake","stea>
| 7         | TRUST_CENTER             | 1          | SNOWFLAKE    | SNOWFLAKE    | 1              | NO           | NO                | <null>  | 2024-09-04T20:42:30+05:30 | 2024-09-04T20:42:30+05:30 | <null>                    | ap-southeast-1 | en54885 | snowflake          | {"connection_name":"snowflake","stea>
| 2         | LOCAL                    | 1          | SNOWFLAKE    | SNOWFLAKE    | 1              | NO           | NO                | <null>  | 2024-09-04T20:41:08+05:30 | 2024-09-04T20:41:08+05:30 | <null>                    | ap-southeast-1 | en54885 | snowflake          | {"connection_name":"snowflake","stea>
| 13        | SECURITY_ESSENTIALS      | 1          | SNOWFLAKE    | SNOWFLAKE    | 1              | NO           | NO                | <null>  | 2024-09-04T20:43:08+05:30 | 2024-09-04T20:43:08+05:30 | <null>                    | ap-southeast-1 | en54885 | snowflake          | {"connection_name":"snowflake","stea>
| 5         | TELEMETRY                | 1          | SNOWFLAKE    | SNOWFLAKE    | 1              | NO           | NO                | <null>  | 2024-09-04T20:42:28+05:30 | 2024-09-04T20:42:28+05:30 | <null>                    | ap-southeast-1 | en54885 | snowflake          | {"connection_name":"snowflake","stea>
| 9         | CIS_COMMON               | 1          | SNOWFLAKE    | SNOWFLAKE    | 1              | NO           | NO                | <null>  | 2024-09-04T20:42:52+05:30 | 2024-09-04T20:42:52+05:30 | <null>                    | ap-southeast-1 | en54885 | snowflake          | {"connection_name":"snowflake","stea>

> select * from snowflake_role
+---------------+---------------------------+-------------------+-----------------------------------------------------------------------------------+---------------+------------------+------------+------------+--------------+-------+----------------+---------+--------------------+--------------------------------->
| name          | created_on                | assigned_to_users | comment                                                                           | granted_roles | granted_to_roles | is_current | is_default | is_inherited | owner | region         | account | sp_connection_name | sp_ctx                          >
+---------------+---------------------------+-------------------+-----------------------------------------------------------------------------------+---------------+------------------+------------+------------+--------------+-------+----------------+---------+--------------------+--------------------------------->
| SYSADMIN      | 2024-09-04T20:12:21+05:30 | 0                 | System administrator can create and manage databases and warehouses.              | 0             | 1                | N          | N          | Y            |       | ap-southeast-1 | en54885 | snowflake          | {"connection_name":"snowflake",">
| ORGADMIN      | 2024-09-04T20:12:22+05:30 | 1                 | Organization administrator can manage organizations and accounts in organizations | 0             | 0                | N          | N          | N            |       | ap-southeast-1 | en54885 | snowflake          | {"connection_name":"snowflake",">
| PUBLIC        | 2024-09-04T20:12:21+05:30 | 0                 | Public role is automatically available to every user in the account.              | 0             | 0                | N          | N          | Y            |       | ap-southeast-1 | en54885 | snowflake          | {"connection_name":"snowflake",">
| USERADMIN     | 2024-09-04T20:12:21+05:30 | 0                 | User administrator can create and manage users and roles                          | 0             | 1                | N          | N          | Y            |       | ap-southeast-1 | en54885 | snowflake          | {"connection_name":"snowflake",">
| ACCOUNTADMIN  | 2024-09-04T20:12:21+05:30 | 1                 | Account administrator can manage all aspects of the account.                      | 2             | 0                | Y          | Y          | N            |       | ap-southeast-1 | en54885 | snowflake          | {"connection_name":"snowflake",">
| SECURITYADMIN | 2024-09-04T20:12:21+05:30 | 0                 | Security administrator can manage security aspects of the account.                | 1             | 1                | N          | N          | Y            |       | ap-southeast-1 | en54885 | snowflake          | {"connection_name":"snowflake",">
+---------------+---------------------------+-------------------+-----------------------------------------------------------------------------------+---------------+------------------+------------+------------+--------------+-------+----------------+---------+--------------------+--------------------------------->

> select * from snowflake_role_grant where role = 'ACCOUNTADMIN'
+--------------+---------------------------+------------+--------------+------------+----------------+---------+--------------------+----------------------------------------------------------------------+----------------------------------------------------------------------+
| role         | created_on                | granted_to | grantee_name | granted_by | region         | account | sp_connection_name | sp_ctx                                                               | _ctx                                                                 |
+--------------+---------------------------+------------+--------------+------------+----------------+---------+--------------------+----------------------------------------------------------------------+----------------------------------------------------------------------+
| ACCOUNTADMIN | 2024-09-04T20:12:21+05:30 | USER       | PARTHA       |            | ap-southeast-1 | en54885 | snowflake          | {"connection_name":"snowflake","steampipe":{"sdk_version":"5.10.1"}} | {"connection_name":"snowflake","steampipe":{"sdk_version":"5.10.1"}} |
+--------------+---------------------------+------------+--------------+------------+----------------+---------+--------------------+----------------------------------------------------------------------+------------------------------------------------------------------

> select * from snowflake_login_history
+-------------+---------------------------+------------+-----------+----------------+----------------------+-------------------------+-----------------------------+------------------------------+------------+------------+---------------+------------------+----------------+---------+--------------------+---------->
| event_id    | event_timestamp           | event_type | user_name | client_ip      | reported_client_type | reported_client_version | first_authentication_factor | second_authentication_factor | is_success | error_code | error_message | related_event_id | region         | account | sp_connection_name | sp_ctx   >
+-------------+---------------------------+------------+-----------+----------------+----------------------+-------------------------+-----------------------------+------------------------------+------------+------------+---------------+------------------+----------------+---------+--------------------+---------->
| 43424286265 | 2024-09-05T10:51:26+05:30 | LOGIN      | PARTHA    | 122.164.86.26  | OTHER                | 1.10.1                  | PASSWORD                    | <null>                       | YES        | <null>     | <null>        | 0                | ap-southeast-1 | en54885 | snowflake          | {"connect>
| 43424286269 | 2024-09-05T11:21:22+05:30 | LOGIN      | PARTHA    | 122.164.86.26  | OTHER                | 1.10.1                  | PASSWORD                    | <null>                       | YES        | <null>     | <null>        | 0                | ap-southeast-1 | en54885 | snowflake          | {"connect>

> select * from snowflake_database
+-----------------------+---------------------------+-----------------------------------------------------------------------+------------+------------+---------+---------------------------------------------------------+--------------+----------------+----------------+---------+--------------------+--------------->
| name                  | created_on                | comment                                                               | is_current | is_default | options | origin                                                  | owner        | retention_time | region         | account | sp_connection_name | sp_ctx        >
+-----------------------+---------------------------+-----------------------------------------------------------------------+------------+------------+---------+---------------------------------------------------------+--------------+----------------+----------------+---------+--------------------+--------------->
| SNOWFLAKE             | 2024-09-04T20:12:22+05:30 |                                                                       | N          | N          |         | SNOWFLAKE.ACCOUNT_USAGE                                 |              | 0              | ap-southeast-1 | en54885 | snowflake          | {"connection_n>
| SNOWFLAKE_SAMPLE_DATA | 2024-09-04T20:12:26+05:30 | Preloaded TPCH Data provided by Snowflake during account provisioning | N          | N          |         | SFSALESSHARED.SFC_SAMPLES_AWSAPSOUTHEAST1SG.SAMPLE_DATA | ACCOUNTADMIN | 0              | ap-southeast-1 | en54885 | snowflake          | {"connection_n>
+-----------------------+---------------------------+-----------------------------------------------------------------------+------------+------------+---------+---------------------------------------------------------+--------------+----------------+----------------+---------+--------------------+--------------->

> select * from snowflake_account_parameter
+--------------------------------------------------------------+----------------------------------+----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------>
| key                                                          | value                            | default                          | description                                                                                                                                                                        >
+--------------------------------------------------------------+----------------------------------+----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------>
| ABORT_DETACHED_QUERY                                         | false                            | false                            | If true, Snowflake will automatically abort queries when it detects that the client has disappeared.                                                                               >
| BINARY_OUTPUT_FORMAT                                         | HEX                              | HEX                              | display format for binary                                                                                                                                                          >
| AUTOCOMMIT_API_SUPPORTED                                     | true                             | true                             | Whether autocommit feature is enabled for this client. This parameter is for                                                                                                       >

```

</details>
